### PR TITLE
Add TrailImage Model

### DIFF
--- a/src/main/java/com/project3/project3/model/TrailImage.java
+++ b/src/main/java/com/project3/project3/model/TrailImage.java
@@ -1,0 +1,69 @@
+package com.project3.project3.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "trail_images")
+public class TrailImage {
+
+    @Id
+    private String id;
+
+    private String trailId;
+    private String imageUrl;
+    private String userId;
+    private String description;
+
+    // Default constructor
+    public TrailImage() {}
+
+    // Constructor
+    public TrailImage(String trailId, String imageUrl, String userId, String description) {
+        this.trailId = trailId;
+        this.imageUrl = imageUrl;
+        this.userId = userId;
+        this.description = description;
+    }
+
+    // Getters and Setters
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTrailId() {
+        return trailId;
+    }
+
+    public void setTrailId(String trailId) {
+        this.trailId = trailId;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}
+


### PR DESCRIPTION
**Summary**  
This PR introduces the `TrailImage` model to represent and store images associated with trails, including metadata like uploader information and descriptions.

**Changes Made**
- Added the `TrailImage` model with the following fields:
  - `id`: Unique identifier for each image (auto-generated by MongoDB).
  - `trailId`: ID of the trail associated with this image.
  - `imageUrl`: URL pointing to the image stored in cloud storage.
  - `userId`: ID of the user who uploaded the image.
  - `description`: Optional description or caption for the image.

**Additional Notes**  
- This model enables users to view images related to each trail, enriching the trail experience with visual content.
- Includes a default constructor and a parameterized constructor to set core image attributes.
- Getters and setters are provided for each field to allow easy access and manipulation of `TrailImage` data.