### PR TITLE
Added Badge controller tests

### DIFF
--- a/src/test/java/com/project3/project3/controller/AdminControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/AdminControllerTest.java
@@ -1,0 +1,126 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.User;
+import com.project3.project3.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class AdminControllerTest {
+
+    @InjectMocks
+    private AdminController adminController;
+
+    @Mock
+    private UserService userService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testCreateUser_Success() {
+        User user = new User();
+        user.setId("1");
+        user.setUsername("johndoe");
+
+        when(userService.saveUser(user)).thenReturn(user);
+
+        ResponseEntity<User> response = adminController.createUser(user);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("johndoe", response.getBody().getUsername());
+    }
+
+    @Test
+    public void testCreateUser_Failure() {
+        User user = new User();
+
+        when(userService.saveUser(user)).thenReturn(null);
+
+        ResponseEntity<User> response = adminController.createUser(user);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
+    public void testGetAllUsers() {
+        User user1 = new User();
+        user1.setId("1");
+        user1.setUsername("johndoe");
+
+        User user2 = new User();
+        user2.setId("2");
+        user2.setUsername("janedoe");
+
+        when(userService.getAllUsers()).thenReturn(Arrays.asList(user1, user2));
+
+        ResponseEntity<List<User>> response = adminController.getAllUsers();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+    }
+
+    @Test
+    public void testAssignRoleToUser_Success() {
+        User user = new User();
+        user.setId("1");
+        user.setRoles(Arrays.asList("ROLE_ADMIN"));
+
+        when(userService.assignRole("1", "ROLE_ADMIN")).thenReturn(Optional.of(user));
+
+        ResponseEntity<User> response = adminController.assignRoleToUser("1", "ROLE_ADMIN");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().getRoles().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void testAssignRoleToUser_Failure() {
+        when(userService.assignRole("1", "ROLE_ADMIN")).thenReturn(Optional.empty());
+
+        ResponseEntity<User> response = adminController.assignRoleToUser("1", "ROLE_ADMIN");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
+    public void testGetUserRoles_Success() {
+        when(userService.getUserRoles("1")).thenReturn(Optional.of(Arrays.asList("ROLE_ADMIN", "ROLE_USER")));
+
+        ResponseEntity<List<String>> response = adminController.getUserRoles("1");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+        assertTrue(response.getBody().contains("ROLE_ADMIN"));
+    }
+
+    @Test
+    public void testGetUserRoles_Failure() {
+        when(userService.getUserRoles("1")).thenReturn(Optional.empty());
+
+        ResponseEntity<List<String>> response = adminController.getUserRoles("1");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+}
+

--- a/src/test/java/com/project3/project3/controller/AuthControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/AuthControllerTest.java
@@ -1,0 +1,139 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.AuthRequest;
+import com.project3.project3.model.AuthResponse;
+import com.project3.project3.model.User;
+import com.project3.project3.service.JwtService;
+import com.project3.project3.service.MilestonesService;
+import com.project3.project3.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerTest {
+
+    @InjectMocks
+    private AuthController authController;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MilestonesService milestonesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testLogin_Success() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("testuser", "password");
+        UserDetails userDetails = mock(UserDetails.class);
+        User user = new User();
+        user.setId("123");
+        user.setUsername("testuser");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
+        when(userService.loadUserByUsername("testuser")).thenReturn(userDetails);
+        when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+        when(jwtService.generateToken("123", userDetails.getAuthorities())).thenReturn("mockToken");
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertTrue(response.getBody() instanceof AuthResponse);
+        assertEquals("mockToken", ((AuthResponse) response.getBody()).getToken());
+    }
+
+    @Test
+    void testLogin_UserNotFound() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("nonexistent", "password");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
+        when(userService.findUserByUsername("nonexistent")).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        assertEquals("User not found with username: nonexistent", response.getBody());
+    }
+
+    @Test
+    void testLogin_InvalidCredentials() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("testuser", "wrongpassword");
+
+        doThrow(BadCredentialsException.class).when(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(401, response.getStatusCode().value());
+        assertEquals("Invalid username or password", response.getBody());
+    }
+
+    @Test
+    void testRegister_Success() {
+        // Arrange
+        User user = new User();
+        user.setUsername("newuser");
+        user.setEmail("newuser@example.com");
+
+        User savedUser = new User();
+        savedUser.setId("123");
+        savedUser.setUsername("newuser");
+
+        when(userService.saveUser(user)).thenReturn(savedUser);
+
+        // Act
+        ResponseEntity<?> response = authController.register(user);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("User registered successfully. Please log in.", response.getBody());
+        verify(milestonesService, times(1)).createMilestones("123");
+    }
+
+    @Test
+    void testRegister_Error() {
+        // Arrange
+        User user = new User();
+        user.setUsername("erroruser");
+
+        when(userService.saveUser(user)).thenThrow(RuntimeException.class);
+
+        // Act
+        ResponseEntity<?> response = authController.register(user);
+
+        // Assert
+        assertEquals(500, response.getStatusCode().value());
+        assertEquals("An error occurred while creating the account.", response.getBody());
+    }
+}

--- a/src/test/java/com/project3/project3/controller/BadgeControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/BadgeControllerTest.java
@@ -1,0 +1,99 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Badge;
+import com.project3.project3.model.BadgeType;
+import com.project3.project3.service.BadgeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BadgeControllerTest {
+
+    @InjectMocks
+    private BadgeController badgeController;
+
+    @Mock
+    private BadgeService badgeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllBadges() {
+        List<Badge> badges = new ArrayList<>();
+        badges.add(new Badge("National Parks Badge", "Visit 5 national parks", BadgeType.NATIONAL_PARKS, "url1"));
+        badges.add(new Badge("Distance Badge", "Hike 100 miles", BadgeType.DISTANCE, "url2"));
+
+        when(badgeService.getAllBadges()).thenReturn(badges);
+
+        ResponseEntity<List<Badge>> response = badgeController.getAllBadges();
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+        verify(badgeService, times(1)).getAllBadges();
+    }
+
+    @Test
+    void testGetBadgeById_Found() {
+        Badge badge = new Badge("Elevation Badge", "Climb 10,000 feet", BadgeType.ELEVATION, "url3");
+        when(badgeService.getBadgeById("1")).thenReturn(Optional.of(badge));
+
+        ResponseEntity<Badge> response = badgeController.getBadgeById("1");
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals("Elevation Badge", response.getBody().getName());
+        verify(badgeService, times(1)).getBadgeById("1");
+    }
+
+    @Test
+    void testGetBadgeById_NotFound() {
+        when(badgeService.getBadgeById("99")).thenReturn(Optional.empty());
+
+        ResponseEntity<Badge> response = badgeController.getBadgeById("99");
+        assertEquals(404, response.getStatusCode().value());
+        assertNull(response.getBody());
+        verify(badgeService, times(1)).getBadgeById("99");
+    }
+
+    @Test
+    void testCreateBadge() {
+        Badge badge = new Badge("Total Hikes Badge", "Complete 50 hikes", BadgeType.TOTAL_HIKES, "url4");
+        when(badgeService.createBadge(badge)).thenReturn(badge);
+
+        ResponseEntity<Badge> response = badgeController.createBadge(badge);
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals("Total Hikes Badge", response.getBody().getName());
+        verify(badgeService, times(1)).createBadge(badge);
+    }
+
+    @Test
+    void testDeleteBadge_Success() {
+        when(badgeService.deleteBadge("1")).thenReturn(true);
+
+        ResponseEntity<Void> response = badgeController.deleteBadge("1");
+        assertEquals(204, response.getStatusCode().value());
+        verify(badgeService, times(1)).deleteBadge("1");
+    }
+
+    @Test
+    void testDeleteBadge_NotFound() {
+        when(badgeService.deleteBadge("99")).thenReturn(false);
+
+        ResponseEntity<Void> response = badgeController.deleteBadge("99");
+        assertEquals(404, response.getStatusCode().value());
+        verify(badgeService, times(1)).deleteBadge("99");
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds unit tests for the `BadgeController` class. The tests cover all endpoints, including:
- Fetching all badges (`GET /api/badges`)
- Fetching a badge by ID (`GET /api/badges/{id}`)
- Creating a new badge (`POST /api/badges`)
- Deleting a badge (`DELETE /api/badges/{id}`)

### Key Changes
1. Added `BadgeControllerTest.java` under `src/test/java/com/project3/project3/controller/`.
2. Included mock responses for the `BadgeService` to simulate:
   - Success and failure scenarios for fetching, creating, and deleting badges.
   - Validation of proper HTTP responses (`200`, `404`, `204`).
3. Used `BadgeType` enum values (`NATIONAL_PARKS`, `DISTANCE`, `ELEVATION`, `TOTAL_HIKES`) for test data.

### Test Cases
- **Get all badges:** Ensures all badges are fetched and match the mock data.
- **Get badge by ID:**
  - Success: Returns the badge with `200 OK`.
  - Failure: Returns `404 Not Found`.
- **Create badge:** Verifies badge creation returns the correct response.
- **Delete badge:**
  - Success: Deletes the badge and returns `204 No Content`.
  - Failure: Returns `404 Not Found`.

### Notes
- Updated test data to include meaningful examples for badge attributes.
- Verified all tests pass successfully with mock dependencies.

### Labels
- `feature-tests`
- `badge-controller`
- `ready-for-review`
