### PR TITLE
Add Unit Tests for JwtRequestFilter

### DIFF
--- a/src/test/java/com/project3/project3/controller/AuthControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/AuthControllerTest.java
@@ -1,0 +1,139 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.AuthRequest;
+import com.project3.project3.model.AuthResponse;
+import com.project3.project3.model.User;
+import com.project3.project3.service.JwtService;
+import com.project3.project3.service.MilestonesService;
+import com.project3.project3.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerTest {
+
+    @InjectMocks
+    private AuthController authController;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MilestonesService milestonesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testLogin_Success() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("testuser", "password");
+        UserDetails userDetails = mock(UserDetails.class);
+        User user = new User();
+        user.setId("123");
+        user.setUsername("testuser");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
+        when(userService.loadUserByUsername("testuser")).thenReturn(userDetails);
+        when(userService.findUserByUsername("testuser")).thenReturn(Optional.of(user));
+        when(jwtService.generateToken("123", userDetails.getAuthorities())).thenReturn("mockToken");
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertTrue(response.getBody() instanceof AuthResponse);
+        assertEquals("mockToken", ((AuthResponse) response.getBody()).getToken());
+    }
+
+    @Test
+    void testLogin_UserNotFound() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("nonexistent", "password");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(null);
+        when(userService.findUserByUsername("nonexistent")).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        assertEquals("User not found with username: nonexistent", response.getBody());
+    }
+
+    @Test
+    void testLogin_InvalidCredentials() {
+        // Arrange
+        AuthRequest authRequest = new AuthRequest("testuser", "wrongpassword");
+
+        doThrow(BadCredentialsException.class).when(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+
+        // Act
+        ResponseEntity<?> response = authController.login(authRequest);
+
+        // Assert
+        assertEquals(401, response.getStatusCode().value());
+        assertEquals("Invalid username or password", response.getBody());
+    }
+
+    @Test
+    void testRegister_Success() {
+        // Arrange
+        User user = new User();
+        user.setUsername("newuser");
+        user.setEmail("newuser@example.com");
+
+        User savedUser = new User();
+        savedUser.setId("123");
+        savedUser.setUsername("newuser");
+
+        when(userService.saveUser(user)).thenReturn(savedUser);
+
+        // Act
+        ResponseEntity<?> response = authController.register(user);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("User registered successfully. Please log in.", response.getBody());
+        verify(milestonesService, times(1)).createMilestones("123");
+    }
+
+    @Test
+    void testRegister_Error() {
+        // Arrange
+        User user = new User();
+        user.setUsername("erroruser");
+
+        when(userService.saveUser(user)).thenThrow(RuntimeException.class);
+
+        // Act
+        ResponseEntity<?> response = authController.register(user);
+
+        // Assert
+        assertEquals(500, response.getStatusCode().value());
+        assertEquals("An error occurred while creating the account.", response.getBody());
+    }
+}

--- a/src/test/java/com/project3/project3/controller/BadgeControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/BadgeControllerTest.java
@@ -1,0 +1,99 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Badge;
+import com.project3.project3.model.BadgeType;
+import com.project3.project3.service.BadgeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BadgeControllerTest {
+
+    @InjectMocks
+    private BadgeController badgeController;
+
+    @Mock
+    private BadgeService badgeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllBadges() {
+        List<Badge> badges = new ArrayList<>();
+        badges.add(new Badge("National Parks Badge", "Visit 5 national parks", BadgeType.NATIONAL_PARKS, "url1"));
+        badges.add(new Badge("Distance Badge", "Hike 100 miles", BadgeType.DISTANCE, "url2"));
+
+        when(badgeService.getAllBadges()).thenReturn(badges);
+
+        ResponseEntity<List<Badge>> response = badgeController.getAllBadges();
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals(2, response.getBody().size());
+        verify(badgeService, times(1)).getAllBadges();
+    }
+
+    @Test
+    void testGetBadgeById_Found() {
+        Badge badge = new Badge("Elevation Badge", "Climb 10,000 feet", BadgeType.ELEVATION, "url3");
+        when(badgeService.getBadgeById("1")).thenReturn(Optional.of(badge));
+
+        ResponseEntity<Badge> response = badgeController.getBadgeById("1");
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals("Elevation Badge", response.getBody().getName());
+        verify(badgeService, times(1)).getBadgeById("1");
+    }
+
+    @Test
+    void testGetBadgeById_NotFound() {
+        when(badgeService.getBadgeById("99")).thenReturn(Optional.empty());
+
+        ResponseEntity<Badge> response = badgeController.getBadgeById("99");
+        assertEquals(404, response.getStatusCode().value());
+        assertNull(response.getBody());
+        verify(badgeService, times(1)).getBadgeById("99");
+    }
+
+    @Test
+    void testCreateBadge() {
+        Badge badge = new Badge("Total Hikes Badge", "Complete 50 hikes", BadgeType.TOTAL_HIKES, "url4");
+        when(badgeService.createBadge(badge)).thenReturn(badge);
+
+        ResponseEntity<Badge> response = badgeController.createBadge(badge);
+        assertEquals(200, response.getStatusCode().value());
+        assertNotNull(response.getBody());
+        assertEquals("Total Hikes Badge", response.getBody().getName());
+        verify(badgeService, times(1)).createBadge(badge);
+    }
+
+    @Test
+    void testDeleteBadge_Success() {
+        when(badgeService.deleteBadge("1")).thenReturn(true);
+
+        ResponseEntity<Void> response = badgeController.deleteBadge("1");
+        assertEquals(204, response.getStatusCode().value());
+        verify(badgeService, times(1)).deleteBadge("1");
+    }
+
+    @Test
+    void testDeleteBadge_NotFound() {
+        when(badgeService.deleteBadge("99")).thenReturn(false);
+
+        ResponseEntity<Void> response = badgeController.deleteBadge("99");
+        assertEquals(404, response.getStatusCode().value());
+        verify(badgeService, times(1)).deleteBadge("99");
+    }
+}

--- a/src/test/java/com/project3/project3/controller/CheckInControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/CheckInControllerTest.java
@@ -1,0 +1,108 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.CheckIn;
+import com.project3.project3.service.CheckInService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class CheckInControllerTest {
+
+    @InjectMocks
+    private CheckInController checkInController;
+
+    @Mock
+    private CheckInService checkInService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetUserCheckIns() {
+        // Arrange
+        String userId = "user123";
+        CheckIn checkIn1 = new CheckIn("trail1", userId, "Trail Name 1", LocalDateTime.now());
+        CheckIn checkIn2 = new CheckIn("trail2", userId, "Trail Name 2", LocalDateTime.now());
+        when(checkInService.getCheckInsByUserId(userId)).thenReturn(Arrays.asList(checkIn1, checkIn2));
+
+        // Act
+        ResponseEntity<List<CheckIn>> response = checkInController.getUserCheckIns(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(checkInService, times(1)).getCheckInsByUserId(userId);
+    }
+
+    @Test
+    void testGetTrailCheckIns() {
+        // Arrange
+        String trailId = "trail123";
+        CheckIn checkIn1 = new CheckIn(trailId, "user1", "Trail Name 1", LocalDateTime.now());
+        CheckIn checkIn2 = new CheckIn(trailId, "user2", "Trail Name 2", LocalDateTime.now());
+        when(checkInService.getCheckInsByTrailId(trailId)).thenReturn(Arrays.asList(checkIn1, checkIn2));
+
+        // Act
+        ResponseEntity<List<CheckIn>> response = checkInController.getTrailCheckIns(trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(checkInService, times(1)).getCheckInsByTrailId(trailId);
+    }
+
+    @Test
+    void testCreateCheckIn() {
+        // Arrange
+        CheckIn checkIn = new CheckIn("trail123", "user123", "Trail Name", LocalDateTime.now());
+        when(checkInService.createCheckIn(checkIn)).thenReturn(checkIn);
+
+        // Act
+        ResponseEntity<CheckIn> response = checkInController.createCheckIn(checkIn);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(checkIn, response.getBody());
+        verify(checkInService, times(1)).createCheckIn(checkIn);
+    }
+
+    @Test
+    void testDeleteCheckIn_Success() {
+        // Arrange
+        String checkInId = "checkIn123";
+        when(checkInService.deleteCheckIn(checkInId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = checkInController.deleteCheckIn(checkInId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(checkInService, times(1)).deleteCheckIn(checkInId);
+    }
+
+    @Test
+    void testDeleteCheckIn_NotFound() {
+        // Arrange
+        String checkInId = "checkInNotFound";
+        when(checkInService.deleteCheckIn(checkInId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = checkInController.deleteCheckIn(checkInId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(checkInService, times(1)).deleteCheckIn(checkInId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/FavoriteTrailControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/FavoriteTrailControllerTest.java
@@ -1,0 +1,94 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.FavoriteTrail;
+import com.project3.project3.service.FavoriteTrailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class FavoriteTrailControllerTest {
+
+    @InjectMocks
+    private FavoriteTrailController favoriteTrailController;
+
+    @Mock
+    private FavoriteTrailService favoriteTrailService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetUserFavorites() {
+        // Arrange
+        String userId = "user123";
+        FavoriteTrail favorite1 = new FavoriteTrail(userId, "trail1", LocalDateTime.now());
+        FavoriteTrail favorite2 = new FavoriteTrail(userId, "trail2", LocalDateTime.now());
+        when(favoriteTrailService.getFavoritesByUserId(userId)).thenReturn(Arrays.asList(favorite1, favorite2));
+
+        // Act
+        ResponseEntity<List<FavoriteTrail>> response = favoriteTrailController.getUserFavorites(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(favoriteTrailService, times(1)).getFavoritesByUserId(userId);
+    }
+
+    @Test
+    void testAddFavoriteTrail() {
+        // Arrange
+        String userId = "user123";
+        String trailId = "trail123";
+        FavoriteTrail favoriteTrail = new FavoriteTrail(userId, trailId, LocalDateTime.now());
+        when(favoriteTrailService.addFavoriteTrail(any(FavoriteTrail.class))).thenReturn(favoriteTrail);
+
+        // Act
+        ResponseEntity<FavoriteTrail> response = favoriteTrailController.addFavoriteTrail(userId, trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(userId, response.getBody().getUserId());
+        assertEquals(trailId, response.getBody().getTrailId());
+        verify(favoriteTrailService, times(1)).addFavoriteTrail(any(FavoriteTrail.class));
+    }
+
+    @Test
+    void testRemoveFavoriteTrail_Success() {
+        // Arrange
+        String favoriteId = "favorite123";
+        when(favoriteTrailService.removeFavoriteTrail(favoriteId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = favoriteTrailController.removeFavoriteTrail(favoriteId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(favoriteTrailService, times(1)).removeFavoriteTrail(favoriteId);
+    }
+
+    @Test
+    void testRemoveFavoriteTrail_NotFound() {
+        // Arrange
+        String favoriteId = "nonexistent";
+        when(favoriteTrailService.removeFavoriteTrail(favoriteId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = favoriteTrailController.removeFavoriteTrail(favoriteId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(favoriteTrailService, times(1)).removeFavoriteTrail(favoriteId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/HikeControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/HikeControllerTest.java
@@ -1,0 +1,124 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Hike;
+import com.project3.project3.service.HikeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class HikeControllerTest {
+
+    @InjectMocks
+    private HikeController hikeController;
+
+    @Mock
+    private HikeService hikeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testStartHike() {
+        // Arrange
+        Hike hike = new Hike("user123", "trail123", null, LocalDateTime.now(), null, null, null);
+        when(hikeService.startHike(hike)).thenReturn(hike);
+
+        // Act
+        ResponseEntity<Hike> response = hikeController.startHike(hike);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("user123", response.getBody().getUserId());
+        verify(hikeService, times(1)).startHike(hike);
+    }
+
+    @Test
+    void testCompleteHike_Success() {
+        // Arrange
+        String hikeId = "hike123";
+        Double distance = 5.0;
+        Double elevationGain = 200.0;
+        List<List<Double>> coordinates = Arrays.asList(Arrays.asList(36.0, -121.0), Arrays.asList(36.1, -121.1));
+        Hike completedHike = new Hike("user123", "trail123", "encodedPolyline", LocalDateTime.now(), LocalDateTime.now(), distance, elevationGain);
+        when(hikeService.completeHike(hikeId, distance, elevationGain, coordinates)).thenReturn(Optional.of(completedHike));
+
+        // Act
+        ResponseEntity<Hike> response = hikeController.completeHike(hikeId, distance, elevationGain, coordinates);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(distance, response.getBody().getDistance());
+        verify(hikeService, times(1)).completeHike(hikeId, distance, elevationGain, coordinates);
+    }
+
+    @Test
+    void testCompleteHike_NotFound() {
+        // Arrange
+        String hikeId = "nonexistent";
+        when(hikeService.completeHike(hikeId, 5.0, 200.0, null)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<Hike> response = hikeController.completeHike(hikeId, 5.0, 200.0, null);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(hikeService, times(1)).completeHike(hikeId, 5.0, 200.0, null);
+    }
+
+    @Test
+    void testGetHikesByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<Hike> hikes = Arrays.asList(new Hike(), new Hike());
+        when(hikeService.getHikesByUserId(userId)).thenReturn(hikes);
+
+        // Act
+        ResponseEntity<List<Hike>> response = hikeController.getHikesByUserId(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(hikeService, times(1)).getHikesByUserId(userId);
+    }
+
+    @Test
+    void testDeleteHike_Success() {
+        // Arrange
+        String hikeId = "hike123";
+        when(hikeService.deleteHikeById(hikeId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = hikeController.deleteHike(hikeId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(hikeService, times(1)).deleteHikeById(hikeId);
+    }
+
+    @Test
+    void testDeleteHike_NotFound() {
+        // Arrange
+        String hikeId = "nonexistent";
+        when(hikeService.deleteHikeById(hikeId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = hikeController.deleteHike(hikeId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(hikeService, times(1)).deleteHikeById(hikeId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/MilestonesControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/MilestonesControllerTest.java
@@ -1,0 +1,74 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Milestones;
+import com.project3.project3.service.MilestonesService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class MilestonesControllerTest {
+
+    @InjectMocks
+    private MilestonesController milestonesController;
+
+    @Mock
+    private MilestonesService milestonesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetMilestonesByUserId() {
+        // Arrange
+        String userId = "user123";
+        Milestones milestones = new Milestones(userId, 5, 20.0, 3, 1000.0, 2);
+        when(milestonesService.getMilestonesByUserId(userId)).thenReturn(milestones);
+
+        // Act
+        ResponseEntity<Milestones> response = milestonesController.getMilestonesByUserId(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(userId, response.getBody().getUserId());
+        assertEquals(5, response.getBody().getTotalHikes());
+        verify(milestonesService, times(1)).getMilestonesByUserId(userId);
+    }
+
+    @Test
+    void testUpdateMilestones() {
+        // Arrange
+        String userId = "user123";
+        Milestones updatedMilestones = new Milestones(userId, 10, 50.0, 5, 1500.0, 3);
+        when(milestonesService.updateMilestones(userId, updatedMilestones)).thenReturn(updatedMilestones);
+
+        // Act
+        ResponseEntity<Milestones> response = milestonesController.updateMilestones(userId, updatedMilestones);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(10, response.getBody().getTotalHikes());
+        verify(milestonesService, times(1)).updateMilestones(userId, updatedMilestones);
+    }
+
+    @Test
+    void testDeleteMilestonesByUserId() {
+        // Arrange
+        String userId = "user123";
+        doNothing().when(milestonesService).deleteMilestonesByUserId(userId);
+
+        // Act
+        ResponseEntity<Void> response = milestonesController.deleteMilestonesByUserId(userId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(milestonesService, times(1)).deleteMilestonesByUserId(userId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/ReviewControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/ReviewControllerTest.java
@@ -1,0 +1,155 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Review;
+import com.project3.project3.service.ReviewService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ReviewControllerTest {
+
+    @InjectMocks
+    private ReviewController reviewController;
+
+    @Mock
+    private ReviewService reviewService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetTrailReviews() {
+        // Arrange
+        String trailId = "trail123";
+        Review review1 = new Review(trailId, "user1", 3.5, 4.0, "Great trail!", LocalDateTime.now());
+        Review review2 = new Review(trailId, "user2", 4.0, 5.0, "Amazing!", LocalDateTime.now());
+        when(reviewService.getReviewsByTrailId(trailId)).thenReturn(Arrays.asList(review1, review2));
+
+        // Act
+        ResponseEntity<List<Review>> response = reviewController.getTrailReviews(trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(reviewService, times(1)).getReviewsByTrailId(trailId);
+    }
+
+    @Test
+    void testGetUserReviews() {
+        // Arrange
+        String userId = "user123";
+        Review review1 = new Review("trail1", userId, 4.0, 5.0, "Awesome!", LocalDateTime.now());
+        Review review2 = new Review("trail2", userId, 3.5, 4.0, "Good experience!", LocalDateTime.now());
+        when(reviewService.getReviewsByUserId(userId)).thenReturn(Arrays.asList(review1, review2));
+
+        // Act
+        ResponseEntity<List<Review>> response = reviewController.getUserReviews(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(reviewService, times(1)).getReviewsByUserId(userId);
+    }
+
+    @Test
+    void testGetAverageDifficulty() {
+        // Arrange
+        String trailId = "trail123";
+        when(reviewService.calculateAverageDifficulty(trailId)).thenReturn(4.0);
+
+        // Act
+        ResponseEntity<Double> response = reviewController.getAverageDifficulty(trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(4.0, response.getBody());
+        verify(reviewService, times(1)).calculateAverageDifficulty(trailId);
+    }
+
+    @Test
+    void testCreateReview() {
+        // Arrange
+        Review review = new Review("trail123", "user123", 4.0, 5.0, "Loved it!", LocalDateTime.now());
+        when(reviewService.createReview(review)).thenReturn(review);
+
+        // Act
+        ResponseEntity<Review> response = reviewController.createReview(review);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("user123", response.getBody().getUserId());
+        verify(reviewService, times(1)).createReview(review);
+    }
+
+    @Test
+    void testUpdateReview_Success() {
+        // Arrange
+        String reviewId = "review123";
+        Review updatedReview = new Review("trail123", "user123", 3.5, 4.0, "Updated comment", LocalDateTime.now());
+        when(reviewService.updateReview(reviewId, updatedReview)).thenReturn(Optional.of(updatedReview));
+
+        // Act
+        ResponseEntity<Review> response = reviewController.updateReview(reviewId, updatedReview);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("Updated comment", response.getBody().getComment());
+        verify(reviewService, times(1)).updateReview(reviewId, updatedReview);
+    }
+
+    @Test
+    void testUpdateReview_NotFound() {
+        // Arrange
+        String reviewId = "nonexistent";
+        Review updatedReview = new Review("trail123", "user123", 3.5, 4.0, "Updated comment", LocalDateTime.now());
+        when(reviewService.updateReview(reviewId, updatedReview)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<Review> response = reviewController.updateReview(reviewId, updatedReview);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(reviewService, times(1)).updateReview(reviewId, updatedReview);
+    }
+
+    @Test
+    void testDeleteReview_Success() {
+        // Arrange
+        String reviewId = "review123";
+        when(reviewService.deleteReview(reviewId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = reviewController.deleteReview(reviewId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(reviewService, times(1)).deleteReview(reviewId);
+    }
+
+    @Test
+    void testDeleteReview_NotFound() {
+        // Arrange
+        String reviewId = "nonexistent";
+        when(reviewService.deleteReview(reviewId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = reviewController.deleteReview(reviewId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(reviewService, times(1)).deleteReview(reviewId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/TrailControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/TrailControllerTest.java
@@ -1,0 +1,172 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.Trail;
+import com.project3.project3.service.TrailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class TrailControllerTest {
+
+    @InjectMocks
+    private TrailController trailController;
+
+    @Mock
+    private TrailService trailService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllTrails() {
+        // Arrange
+        Trail trail1 = new Trail("places1", "Trail 1", "Location 1", "Description 1", null);
+        trail1.setTrailId("trail1");
+        Trail trail2 = new Trail("places2", "Trail 2", "Location 2", "Description 2", null);
+        trail2.setTrailId("trail2");
+        when(trailService.getAllTrails()).thenReturn(Arrays.asList(trail1, trail2));
+
+        // Act
+        ResponseEntity<List<Trail>> response = trailController.getAllTrails();
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(trailService, times(1)).getAllTrails();
+    }
+
+    @Test
+    void testGetTrailById_Success() {
+        // Arrange
+        String trailId = "trail123";
+        Trail trail = new Trail("places1", "Trail Name", "Location", "Description", null);
+        trail.setTrailId(trailId);
+        when(trailService.getTrailById(trailId)).thenReturn(Optional.of(trail));
+
+        // Act
+        ResponseEntity<Trail> response = trailController.getTrailById(trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("Trail Name", response.getBody().getName());
+        verify(trailService, times(1)).getTrailById(trailId);
+    }
+
+    @Test
+    void testGetTrailById_NotFound() {
+        // Arrange
+        String trailId = "nonexistent";
+        when(trailService.getTrailById(trailId)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<Trail> response = trailController.getTrailById(trailId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(trailService, times(1)).getTrailById(trailId);
+    }
+
+    @Test
+    void testGetTrailByPlacesId_Success() {
+        // Arrange
+        String placesId = "places1";
+        Trail trail = new Trail(placesId, "Trail Name", "Location", "Description", null);
+        trail.setTrailId("trail1");
+        when(trailService.getTrailByPlacesId(placesId)).thenReturn(Optional.of(trail));
+
+        // Act
+        ResponseEntity<Trail> response = trailController.getTrailByPlacesId(placesId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(placesId, response.getBody().getPlacesId());
+        verify(trailService, times(1)).getTrailByPlacesId(placesId);
+    }
+
+    @Test
+    void testGetTrailByPlacesId_NotFound() {
+        // Arrange
+        String placesId = "nonexistent";
+        when(trailService.getTrailByPlacesId(placesId)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<Trail> response = trailController.getTrailByPlacesId(placesId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(trailService, times(1)).getTrailByPlacesId(placesId);
+    }
+
+    @Test
+    void testCreateTrail() {
+        // Arrange
+        Trail trail = new Trail("places1", "Trail Name", "Location", "Description", null);
+        trail.setTrailId("trail1");
+        when(trailService.createTrail(trail)).thenReturn(trail);
+
+        // Act
+        ResponseEntity<Trail> response = trailController.createTrail(trail);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("Trail Name", response.getBody().getName());
+        verify(trailService, times(1)).createTrail(trail);
+    }
+
+    @Test
+    void testUpdateTrail() {
+        // Arrange
+        String trailId = "trail123";
+        Trail updatedTrail = new Trail("places1", "Updated Trail", "Updated Location", "Updated Description", null);
+        updatedTrail.setTrailId(trailId);
+        when(trailService.updateTrail(trailId, updatedTrail)).thenReturn(updatedTrail);
+
+        // Act
+        ResponseEntity<Trail> response = trailController.updateTrail(trailId, updatedTrail);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("Updated Trail", response.getBody().getName());
+        verify(trailService, times(1)).updateTrail(trailId, updatedTrail);
+    }
+
+    @Test
+    void testDeleteTrail_Success() {
+        // Arrange
+        String trailId = "trail123";
+        when(trailService.deleteTrail(trailId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = trailController.deleteTrail(trailId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(trailService, times(1)).deleteTrail(trailId);
+    }
+
+    @Test
+    void testDeleteTrail_NotFound() {
+        // Arrange
+        String trailId = "nonexistent";
+        when(trailService.deleteTrail(trailId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = trailController.deleteTrail(trailId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(trailService, times(1)).deleteTrail(trailId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/TrailImageControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/TrailImageControllerTest.java
@@ -1,0 +1,142 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.TrailImage;
+import com.project3.project3.service.ImageService;
+import com.project3.project3.service.TrailImageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class TrailImageControllerTest {
+
+    @InjectMocks
+    private TrailImageController trailImageController;
+
+    @Mock
+    private TrailImageService trailImageService;
+
+    @Mock
+    private ImageService imageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetImagesByTrailId() {
+        // Arrange
+        String trailId = "trail123";
+        TrailImage image1 = new TrailImage(trailId, "imageUrl1", "user1", "Description 1");
+        TrailImage image2 = new TrailImage(trailId, "imageUrl2", "user2", "Description 2");
+        when(trailImageService.getImagesByTrailId(trailId)).thenReturn(Arrays.asList(image1, image2));
+
+        // Act
+        ResponseEntity<List<TrailImage>> response = trailImageController.getImagesByTrailId(trailId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(trailImageService, times(1)).getImagesByTrailId(trailId);
+    }
+
+    @Test
+    void testGetImagesByUserId() {
+        // Arrange
+        String userId = "user123";
+        TrailImage image1 = new TrailImage("trail1", "imageUrl1", userId, "Description 1");
+        TrailImage image2 = new TrailImage("trail2", "imageUrl2", userId, "Description 2");
+        when(trailImageService.getImagesByUserId(userId)).thenReturn(Arrays.asList(image1, image2));
+
+        // Act
+        ResponseEntity<List<TrailImage>> response = trailImageController.getImagesByUserId(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(trailImageService, times(1)).getImagesByUserId(userId);
+    }
+
+    @Test
+    void testUploadTrailImage_Success() throws Exception {
+        // Arrange
+        MultipartFile file = mock(MultipartFile.class);
+        String trailId = "trail123";
+        String userId = "user123";
+        String description = "A beautiful trail";
+        String imageUrl = "https://example.com/image.jpg";
+        TrailImage trailImage = new TrailImage(trailId, imageUrl, userId, description);
+
+        when(imageService.uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("TRAIL_PIC_FOLDER")))
+                .thenReturn(imageUrl);
+        when(trailImageService.saveTrailImage(imageUrl, trailId, userId, description))
+                .thenReturn(trailImage);
+
+        // Act
+        ResponseEntity<TrailImage> response = trailImageController.uploadTrailImage(file, trailId, userId, description);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(imageUrl, response.getBody().getImageUrl());
+        verify(imageService, times(1)).uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("TRAIL_PIC_FOLDER"));
+        verify(trailImageService, times(1)).saveTrailImage(imageUrl, trailId, userId, description);
+    }
+
+    @Test
+    void testUploadTrailImage_Failure() throws Exception {
+        // Arrange
+        MultipartFile file = mock(MultipartFile.class);
+        String trailId = "trail123";
+        String userId = "user123";
+        String description = "A beautiful trail";
+
+        when(imageService.uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("TRAIL_PIC_FOLDER")))
+                .thenThrow(new RuntimeException("Upload failed"));
+
+        // Act
+        ResponseEntity<TrailImage> response = trailImageController.uploadTrailImage(file, trailId, userId, description);
+
+        // Assert
+        assertEquals(500, response.getStatusCode().value());
+        verify(imageService, times(1)).uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("TRAIL_PIC_FOLDER"));
+        verify(trailImageService, times(0)).saveTrailImage(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void testDeleteTrailImage_Success() {
+        // Arrange
+        String imageId = "image123";
+        when(trailImageService.deleteTrailImage(imageId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = trailImageController.deleteTrailImage(imageId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(trailImageService, times(1)).deleteTrailImage(imageId);
+    }
+
+    @Test
+    void testDeleteTrailImage_NotFound() {
+        // Arrange
+        String imageId = "nonexistent";
+        when(trailImageService.deleteTrailImage(imageId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = trailImageController.deleteTrailImage(imageId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(trailImageService, times(1)).deleteTrailImage(imageId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/UserBadgeControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/UserBadgeControllerTest.java
@@ -1,0 +1,126 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.UserBadge;
+import com.project3.project3.service.UserBadgeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class UserBadgeControllerTest {
+
+    @InjectMocks
+    private UserBadgeController userBadgeController;
+
+    @Mock
+    private UserBadgeService userBadgeService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetUserBadges() {
+        // Arrange
+        String userId = "user123";
+        UserBadge badge1 = new UserBadge(userId, "badge1", LocalDateTime.now());
+        UserBadge badge2 = new UserBadge(userId, "badge2", LocalDateTime.now());
+        when(userBadgeService.getUserBadgesByUserId(userId)).thenReturn(Arrays.asList(badge1, badge2));
+
+        // Act
+        ResponseEntity<List<UserBadge>> response = userBadgeController.getUserBadges(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(userBadgeService, times(1)).getUserBadgesByUserId(userId);
+    }
+
+    @Test
+    void testGetUserBadge_Success() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "badge123";
+        UserBadge userBadge = new UserBadge(userId, badgeId, LocalDateTime.now());
+        when(userBadgeService.getUserBadge(userId, badgeId)).thenReturn(Optional.of(userBadge));
+
+        // Act
+        ResponseEntity<UserBadge> response = userBadgeController.getUserBadge(userId, badgeId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(badgeId, response.getBody().getBadgeId());
+        verify(userBadgeService, times(1)).getUserBadge(userId, badgeId);
+    }
+
+    @Test
+    void testGetUserBadge_NotFound() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "nonexistent";
+        when(userBadgeService.getUserBadge(userId, badgeId)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<UserBadge> response = userBadgeController.getUserBadge(userId, badgeId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userBadgeService, times(1)).getUserBadge(userId, badgeId);
+    }
+
+    @Test
+    void testAwardBadgeToUser() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "badge123";
+        UserBadge awardedBadge = new UserBadge(userId, badgeId, LocalDateTime.now());
+        when(userBadgeService.awardBadgeToUser(userId, badgeId)).thenReturn(awardedBadge);
+
+        // Act
+        ResponseEntity<UserBadge> response = userBadgeController.awardBadgeToUser(userId, badgeId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(badgeId, response.getBody().getBadgeId());
+        verify(userBadgeService, times(1)).awardBadgeToUser(userId, badgeId);
+    }
+
+    @Test
+    void testRemoveUserBadge_Success() {
+        // Arrange
+        String badgeId = "badge123";
+        when(userBadgeService.removeBadge(badgeId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = userBadgeController.removeUserBadge("user123", badgeId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(userBadgeService, times(1)).removeBadge(badgeId);
+    }
+
+    @Test
+    void testRemoveUserBadge_NotFound() {
+        // Arrange
+        String badgeId = "nonexistent";
+        when(userBadgeService.removeBadge(badgeId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = userBadgeController.removeUserBadge("user123", badgeId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userBadgeService, times(1)).removeBadge(badgeId);
+    }
+}

--- a/src/test/java/com/project3/project3/controller/UserControllerTest.java
+++ b/src/test/java/com/project3/project3/controller/UserControllerTest.java
@@ -1,0 +1,232 @@
+package com.project3.project3.controller;
+
+import com.project3.project3.model.User;
+import com.project3.project3.service.ImageService;
+import com.project3.project3.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class UserControllerTest {
+
+    @InjectMocks
+    private UserController userController;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ImageService imageService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testFindUserIdByUsername_Success() {
+        // Arrange
+        String username = "testuser";
+        User user = new User();
+        user.setId("123");
+        user.setUsername(username);
+        when(userService.findUserByUsername(username)).thenReturn(Optional.of(user));
+
+        // Act
+        ResponseEntity<String> response = userController.findUserIdByUsername(username);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("123", response.getBody());
+        verify(userService, times(1)).findUserByUsername(username);
+    }
+
+    @Test
+    void testFindUserIdByUsername_NotFound() {
+        // Arrange
+        String username = "nonexistent";
+        when(userService.findUserByUsername(username)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<String> response = userController.findUserIdByUsername(username);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userService, times(1)).findUserByUsername(username);
+    }
+
+    @Test
+    void testFindUserById_Success() {
+        // Arrange
+        String userId = "123";
+        User user = new User();
+        user.setId(userId);
+        when(userService.getUserById(userId)).thenReturn(Optional.of(user));
+
+        // Act
+        ResponseEntity<User> response = userController.findUserById(userId);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(userId, response.getBody().getId());
+        verify(userService, times(1)).getUserById(userId);
+    }
+
+    @Test
+    void testFindUserById_NotFound() {
+        // Arrange
+        String userId = "nonexistent";
+        when(userService.getUserById(userId)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<User> response = userController.findUserById(userId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userService, times(1)).getUserById(userId);
+    }
+
+    @Test
+    void testGetAllUsers() {
+        // Arrange
+        User user1 = new User();
+        user1.setId("1");
+        User user2 = new User();
+        user2.setId("2");
+        when(userService.getAllUsers()).thenReturn(Arrays.asList(user1, user2));
+
+        // Act
+        ResponseEntity<List<User>> response = userController.getAllUsers();
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(2, response.getBody().size());
+        verify(userService, times(1)).getAllUsers();
+    }
+
+    @Test
+    void testCreateUser() {
+        // Arrange
+        User user = new User();
+        user.setUsername("newuser");
+        when(userService.saveUser(user)).thenReturn(user);
+
+        // Act
+        ResponseEntity<User> response = userController.createUser(user);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("newuser", response.getBody().getUsername());
+        verify(userService, times(1)).saveUser(user);
+    }
+
+    @Test
+    void testUpdateUser_Success() {
+        // Arrange
+        String userId = "123";
+        User updatedUser = new User();
+        updatedUser.setUsername("updateduser");
+        when(userService.updateUser(userId, updatedUser)).thenReturn(Optional.of(updatedUser));
+
+        // Act
+        ResponseEntity<User> response = userController.updateUser(userId, updatedUser);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals("updateduser", response.getBody().getUsername());
+        verify(userService, times(1)).updateUser(userId, updatedUser);
+    }
+
+    @Test
+    void testUpdateUser_NotFound() {
+        // Arrange
+        String userId = "nonexistent";
+        User updatedUser = new User();
+        when(userService.updateUser(userId, updatedUser)).thenReturn(Optional.empty());
+
+        // Act
+        ResponseEntity<User> response = userController.updateUser(userId, updatedUser);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userService, times(1)).updateUser(userId, updatedUser);
+    }
+
+    @Test
+    void testDeleteUserById_Success() {
+        // Arrange
+        String userId = "123";
+        when(userService.deleteUserById(userId)).thenReturn(true);
+
+        // Act
+        ResponseEntity<Void> response = userController.deleteUserById(userId);
+
+        // Assert
+        assertEquals(204, response.getStatusCode().value());
+        verify(userService, times(1)).deleteUserById(userId);
+    }
+
+    @Test
+    void testDeleteUserById_NotFound() {
+        // Arrange
+        String userId = "nonexistent";
+        when(userService.deleteUserById(userId)).thenReturn(false);
+
+        // Act
+        ResponseEntity<Void> response = userController.deleteUserById(userId);
+
+        // Assert
+        assertEquals(404, response.getStatusCode().value());
+        verify(userService, times(1)).deleteUserById(userId);
+    }
+
+    @Test
+    void testUploadProfilePicture_Success() throws Exception {
+        // Arrange
+        String userId = "123";
+        MultipartFile file = mock(MultipartFile.class);
+        String imageUrl = "http://example.com/image.jpg";
+        User user = new User();
+        user.setProfilePictureUrl(imageUrl);
+        when(imageService.uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("PROFILE_PIC_FOLDER")))
+                .thenReturn(imageUrl);
+        when(userService.updateProfilePicture(userId, imageUrl)).thenReturn(Optional.of(user));
+
+        // Act
+        ResponseEntity<User> response = userController.uploadProfilePicture(userId, file);
+
+        // Assert
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(imageUrl, response.getBody().getProfilePictureUrl());
+        verify(imageService, times(1)).uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("PROFILE_PIC_FOLDER"));
+        verify(userService, times(1)).updateProfilePicture(userId, imageUrl);
+    }
+
+    @Test
+    void testUploadProfilePicture_Failure() throws Exception {
+        // Arrange
+        String userId = "123";
+        MultipartFile file = mock(MultipartFile.class);
+        when(imageService.uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("PROFILE_PIC_FOLDER")))
+                .thenThrow(new RuntimeException("Upload failed"));
+
+        // Act
+        ResponseEntity<User> response = userController.uploadProfilePicture(userId, file);
+
+        // Assert
+        assertEquals(500, response.getStatusCode().value());
+        verify(imageService, times(1)).uploadImage(file, System.getenv("BUCKET_NAME"), System.getenv("PROFILE_PIC_FOLDER"));
+        verify(userService, times(0)).updateProfilePicture(anyString(), anyString());
+    }
+}

--- a/src/test/java/com/project3/project3/security/JwtRequestFilterTest.java
+++ b/src/test/java/com/project3/project3/security/JwtRequestFilterTest.java
@@ -1,0 +1,113 @@
+package com.project3.project3.security;
+
+import com.project3.project3.service.JwtService;
+import com.project3.project3.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtRequestFilterTest {
+
+    @InjectMocks
+    private JwtRequestFilter jwtRequestFilter;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @BeforeEach
+    public void setUp() {
+        // Clear the security context before each test
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void shouldBypassFilterForAuthEndpoint() throws ServletException, IOException {
+        // Mock request to an auth endpoint
+        when(request.getRequestURI()).thenReturn("/api/auth/login");
+
+        // Execute the filter
+        jwtRequestFilter.doFilterInternal(request, response, chain);
+
+        // Verify that the filter bypassed further processing
+        verify(chain, times(1)).doFilter(request, response);
+        verify(jwtService, never()).extractUserId(anyString());
+    }
+
+    @Test
+    public void shouldAuthenticateUserWithValidToken() throws ServletException, IOException {
+        // Mock a valid JWT token
+        when(request.getHeader("Authorization")).thenReturn("Bearer validToken");
+        when(jwtService.extractUserId("validToken")).thenReturn("userId");
+        when(jwtService.validateToken("validToken", "userId")).thenReturn(true);
+
+        // Mock user details
+        UserDetails userDetails = new User("userId", "password", new ArrayList<>());
+        when(userService.loadUserById("userId")).thenReturn(userDetails);
+
+        // Mock request URI
+        when(request.getRequestURI()).thenReturn("/some/path");
+
+        // Execute the filter
+        jwtRequestFilter.doFilterInternal(request, response, chain);
+
+        // Assert that authentication was set in the SecurityContext
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals("userId", SecurityContextHolder.getContext().getAuthentication().getName());
+
+        // Verify the chain continued processing
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    public void shouldNotAuthenticateUserWithInvalidToken() throws ServletException, IOException {
+        // Mock an invalid JWT token
+        when(request.getHeader("Authorization")).thenReturn("Bearer invalidToken");
+        when(jwtService.extractUserId("invalidToken")).thenReturn("userId");
+        when(jwtService.validateToken("invalidToken", "userId")).thenReturn(false);
+
+        // Mock user details
+        when(userService.loadUserById("userId")).thenReturn(null);
+
+        // Mock request URI
+        when(request.getRequestURI()).thenReturn("/some/path");
+
+        // Execute the filter
+        jwtRequestFilter.doFilterInternal(request, response, chain);
+
+        // Assert that no authentication was set in the SecurityContext
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+
+        // Verify the chain continued processing
+        verify(chain, times(1)).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/project3/project3/service/BadgeServiceTest.java
+++ b/src/test/java/com/project3/project3/service/BadgeServiceTest.java
@@ -1,0 +1,123 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.Badge;
+import com.project3.project3.model.BadgeType;
+import com.project3.project3.repository.BadgeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BadgeServiceTest {
+
+    @InjectMocks
+    private BadgeService badgeService;
+
+    @Mock
+    private BadgeRepository badgeRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllBadges() {
+        // Arrange
+        List<Badge> badges = Arrays.asList(
+                new Badge("National Parks Badge", "Visit 5 national parks", BadgeType.NATIONAL_PARKS, "url1"),
+                new Badge("Distance Badge", "Hike 100 miles", BadgeType.DISTANCE, "url2")
+        );
+        when(badgeRepository.findAll()).thenReturn(badges);
+
+        // Act
+        List<Badge> result = badgeService.getAllBadges();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("National Parks Badge", result.get(0).getName());
+        assertEquals("Distance Badge", result.get(1).getName());
+        verify(badgeRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetBadgeById_Found() {
+        // Arrange
+        Badge badge = new Badge("Elevation Badge", "Climb 10,000 feet", BadgeType.ELEVATION, "url3");
+        when(badgeRepository.findById("1")).thenReturn(Optional.of(badge));
+
+        // Act
+        Optional<Badge> result = badgeService.getBadgeById("1");
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals("Elevation Badge", result.get().getName());
+        verify(badgeRepository, times(1)).findById("1");
+    }
+
+    @Test
+    void testGetBadgeById_NotFound() {
+        // Arrange
+        when(badgeRepository.findById("99")).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Badge> result = badgeService.getBadgeById("99");
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(badgeRepository, times(1)).findById("99");
+    }
+
+    @Test
+    void testCreateBadge() {
+        // Arrange
+        Badge badge = new Badge("Total Hikes Badge", "Complete 50 hikes", BadgeType.TOTAL_HIKES, "url4");
+        when(badgeRepository.save(badge)).thenReturn(badge);
+
+        // Act
+        Badge result = badgeService.createBadge(badge);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("Total Hikes Badge", result.getName());
+        verify(badgeRepository, times(1)).save(badge);
+    }
+
+    @Test
+    void testDeleteBadge_Success() {
+        // Arrange
+        String badgeId = "1";
+        when(badgeRepository.existsById(badgeId)).thenReturn(true);
+
+        // Act
+        boolean result = badgeService.deleteBadge(badgeId);
+
+        // Assert
+        assertTrue(result);
+        verify(badgeRepository, times(1)).existsById(badgeId);
+        verify(badgeRepository, times(1)).deleteById(badgeId);
+    }
+
+    @Test
+    void testDeleteBadge_NotFound() {
+        // Arrange
+        String badgeId = "99";
+        when(badgeRepository.existsById(badgeId)).thenReturn(false);
+
+        // Act
+        boolean result = badgeService.deleteBadge(badgeId);
+
+        // Assert
+        assertFalse(result);
+        verify(badgeRepository, times(1)).existsById(badgeId);
+        verify(badgeRepository, never()).deleteById(badgeId);
+    }
+}

--- a/src/test/java/com/project3/project3/service/CheckInServiceTest.java
+++ b/src/test/java/com/project3/project3/service/CheckInServiceTest.java
@@ -1,0 +1,139 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.CheckIn;
+import com.project3.project3.repository.CheckInRepository;
+import com.project3.project3.utility.CheckInEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CheckInServiceTest {
+
+    @InjectMocks
+    private CheckInService checkInService;
+
+    @Mock
+    private CheckInRepository checkInRepository;
+
+    @Mock
+    private MilestonesService milestonesService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllCheckIns() {
+        // Arrange
+        List<CheckIn> checkIns = Arrays.asList(
+                new CheckIn("trail1", "user1", "Trail Name 1", LocalDateTime.now()),
+                new CheckIn("trail2", "user2", "Trail Name 2", LocalDateTime.now())
+        );
+        when(checkInRepository.findAll()).thenReturn(checkIns);
+
+        // Act
+        List<CheckIn> result = checkInService.getAllCheckIns();
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("Trail Name 1", result.get(0).getName());
+        verify(checkInRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetCheckInsByTrailId() {
+        // Arrange
+        String trailId = "trail123";
+        List<CheckIn> checkIns = Arrays.asList(
+                new CheckIn(trailId, "user1", "Trail Name 1", LocalDateTime.now()),
+                new CheckIn(trailId, "user2", "Trail Name 2", LocalDateTime.now())
+        );
+        when(checkInRepository.findByTrailId(trailId)).thenReturn(checkIns);
+
+        // Act
+        List<CheckIn> result = checkInService.getCheckInsByTrailId(trailId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(checkInRepository, times(1)).findByTrailId(trailId);
+    }
+
+    @Test
+    void testGetCheckInsByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<CheckIn> checkIns = Arrays.asList(
+                new CheckIn("trail1", userId, "Trail Name 1", LocalDateTime.now()),
+                new CheckIn("trail2", userId, "Trail Name 2", LocalDateTime.now())
+        );
+        when(checkInRepository.findByUserId(userId)).thenReturn(checkIns);
+
+        // Act
+        List<CheckIn> result = checkInService.getCheckInsByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(checkInRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testCreateCheckIn() {
+        // Arrange
+        CheckIn checkIn = new CheckIn("trail123", "user123", "Trail Name", LocalDateTime.now());
+        when(checkInRepository.save(any(CheckIn.class))).thenReturn(checkIn);
+
+        // Act
+        CheckIn result = checkInService.createCheckIn(checkIn);
+
+        // Assert
+        assertNotNull(result.getTimestamp());
+        verify(milestonesService, times(1)).incrementNationalParksVisited("user123", "Trail Name");
+        verify(applicationEventPublisher, times(1)).publishEvent(any(CheckInEvent.class));
+        verify(checkInRepository, times(1)).save(checkIn);
+    }
+
+    @Test
+    void testDeleteCheckIn_Success() {
+        // Arrange
+        String checkInId = "checkIn123";
+        when(checkInRepository.existsById(checkInId)).thenReturn(true);
+
+        // Act
+        boolean result = checkInService.deleteCheckIn(checkInId);
+
+        // Assert
+        assertTrue(result);
+        verify(checkInRepository, times(1)).existsById(checkInId);
+        verify(checkInRepository, times(1)).deleteById(checkInId);
+    }
+
+    @Test
+    void testDeleteCheckIn_NotFound() {
+        // Arrange
+        String checkInId = "checkInNotFound";
+        when(checkInRepository.existsById(checkInId)).thenReturn(false);
+
+        // Act
+        boolean result = checkInService.deleteCheckIn(checkInId);
+
+        // Assert
+        assertFalse(result);
+        verify(checkInRepository, times(1)).existsById(checkInId);
+        verify(checkInRepository, never()).deleteById(checkInId);
+    }
+}

--- a/src/test/java/com/project3/project3/service/FavoriteTrailServiceTest.java
+++ b/src/test/java/com/project3/project3/service/FavoriteTrailServiceTest.java
@@ -1,0 +1,97 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.FavoriteTrail;
+import com.project3.project3.repository.FavoriteTrailRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FavoriteTrailServiceTest {
+
+    @InjectMocks
+    private FavoriteTrailService favoriteTrailService;
+
+    @Mock
+    private FavoriteTrailRepository favoriteTrailRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetFavoritesByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<FavoriteTrail> favorites = Arrays.asList(
+                new FavoriteTrail(userId, "trail1", LocalDateTime.now()),
+                new FavoriteTrail(userId, "trail2", LocalDateTime.now())
+        );
+        when(favoriteTrailRepository.findByUserId(userId)).thenReturn(favorites);
+
+        // Act
+        List<FavoriteTrail> result = favoriteTrailService.getFavoritesByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        assertEquals("trail1", result.get(0).getTrailId());
+        assertEquals("trail2", result.get(1).getTrailId());
+        verify(favoriteTrailRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testAddFavoriteTrail() {
+        // Arrange
+        FavoriteTrail favoriteTrail = new FavoriteTrail("user123", "trail123", null);
+        FavoriteTrail savedFavorite = new FavoriteTrail("user123", "trail123", LocalDateTime.now());
+        when(favoriteTrailRepository.save(any(FavoriteTrail.class))).thenReturn(savedFavorite);
+
+        // Act
+        FavoriteTrail result = favoriteTrailService.addFavoriteTrail(favoriteTrail);
+
+        // Assert
+        assertNotNull(result.getFavoritedTimestamp());
+        assertEquals("trail123", result.getTrailId());
+        verify(favoriteTrailRepository, times(1)).save(favoriteTrail);
+    }
+
+    @Test
+    void testRemoveFavoriteTrail_Success() {
+        // Arrange
+        String favoriteId = "favorite123";
+        when(favoriteTrailRepository.existsById(favoriteId)).thenReturn(true);
+
+        // Act
+        boolean result = favoriteTrailService.removeFavoriteTrail(favoriteId);
+
+        // Assert
+        assertTrue(result);
+        verify(favoriteTrailRepository, times(1)).existsById(favoriteId);
+        verify(favoriteTrailRepository, times(1)).deleteById(favoriteId);
+    }
+
+    @Test
+    void testRemoveFavoriteTrail_NotFound() {
+        // Arrange
+        String favoriteId = "nonexistent";
+        when(favoriteTrailRepository.existsById(favoriteId)).thenReturn(false);
+
+        // Act
+        boolean result = favoriteTrailService.removeFavoriteTrail(favoriteId);
+
+        // Assert
+        assertFalse(result);
+        verify(favoriteTrailRepository, times(1)).existsById(favoriteId);
+        verify(favoriteTrailRepository, never()).deleteById(favoriteId);
+    }
+}

--- a/src/test/java/com/project3/project3/service/HikeServiceTest.java
+++ b/src/test/java/com/project3/project3/service/HikeServiceTest.java
@@ -1,0 +1,159 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.Hike;
+import com.project3.project3.repository.HikeRepository;
+import com.project3.project3.utility.HikeEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class HikeServiceTest {
+
+    @InjectMocks
+    private HikeService hikeService;
+
+    @Mock
+    private HikeRepository hikeRepository;
+
+    @Mock
+    private MilestonesService milestonesService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testStartHike() {
+        // Arrange
+        Hike hike = new Hike();
+        hike.setUserId("user123");
+        when(hikeRepository.save(any(Hike.class))).thenReturn(hike);
+
+        // Act
+        Hike result = hikeService.startHike(hike);
+
+        // Assert
+        assertNotNull(result.getStartTime());
+        verify(milestonesService, times(1)).incrementTotalHikes("user123");
+        verify(hikeRepository, times(1)).save(hike);
+    }
+
+    @Test
+    void testCompleteHike_Success() {
+        // Arrange
+        String hikeId = "hike123";
+        Hike existingHike = new Hike();
+        existingHike.setUserId("user123");
+        List<List<Double>> coordinates = Arrays.asList(
+                Arrays.asList(37.7749, -122.4194),
+                Arrays.asList(34.0522, -118.2437)
+        );
+        when(hikeRepository.findById(hikeId)).thenReturn(Optional.of(existingHike));
+        when(hikeRepository.save(any(Hike.class))).thenReturn(existingHike);
+
+        // Act
+        Optional<Hike> result = hikeService.completeHike(hikeId, 5.0, 500.0, coordinates);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertNotNull(result.get().getEndTime());
+        verify(milestonesService, times(1)).incrementDistance("user123", 5.0);
+        verify(milestonesService, times(1)).incrementElevationGain("user123", 500.0);
+        verify(applicationEventPublisher, times(1)).publishEvent(any(HikeEvent.class));
+        verify(hikeRepository, times(1)).save(existingHike);
+    }
+
+    @Test
+    void testCompleteHike_NotFound() {
+        // Arrange
+        String hikeId = "nonexistent";
+        List<List<Double>> coordinates = Arrays.asList(
+                Arrays.asList(37.7749, -122.4194),
+                Arrays.asList(34.0522, -118.2437)
+        );
+        when(hikeRepository.findById(hikeId)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Hike> result = hikeService.completeHike(hikeId, 5.0, 500.0, coordinates);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(hikeRepository, times(1)).findById(hikeId);
+        verifyNoMoreInteractions(hikeRepository, milestonesService, applicationEventPublisher);
+    }
+
+    @Test
+    void testGetHikesByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<Hike> hikes = Arrays.asList(new Hike(), new Hike());
+        when(hikeRepository.findByUserId(userId)).thenReturn(hikes);
+
+        // Act
+        List<Hike> result = hikeService.getHikesByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(hikeRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testGetHikeById_Success() {
+        // Arrange
+        String hikeId = "hike123";
+        Hike hike = new Hike();
+        when(hikeRepository.findById(hikeId)).thenReturn(Optional.of(hike));
+
+        // Act
+        Optional<Hike> result = hikeService.getHikeById(hikeId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        verify(hikeRepository, times(1)).findById(hikeId);
+    }
+
+    @Test
+    void testDeleteHikeById_Success() {
+        // Arrange
+        String hikeId = "hike123";
+        when(hikeRepository.existsById(hikeId)).thenReturn(true);
+
+        // Act
+        boolean result = hikeService.deleteHikeById(hikeId);
+
+        // Assert
+        assertTrue(result);
+        verify(hikeRepository, times(1)).existsById(hikeId);
+        verify(hikeRepository, times(1)).deleteById(hikeId);
+    }
+
+    @Test
+    void testDeleteHikeById_NotFound() {
+        // Arrange
+        String hikeId = "nonexistent";
+        when(hikeRepository.existsById(hikeId)).thenReturn(false);
+
+        // Act
+        boolean result = hikeService.deleteHikeById(hikeId);
+
+        // Assert
+        assertFalse(result);
+        verify(hikeRepository, times(1)).existsById(hikeId);
+        verify(hikeRepository, never()).deleteById(hikeId);
+    }
+}

--- a/src/test/java/com/project3/project3/service/MilestonesServiceTest.java
+++ b/src/test/java/com/project3/project3/service/MilestonesServiceTest.java
@@ -1,0 +1,121 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.Milestones;
+import com.project3.project3.repository.MilestonesRepository;
+import com.project3.project3.repository.UserBadgeRepository;
+import com.project3.project3.utility.NationalParksList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class MilestonesServiceTest {
+
+    @InjectMocks
+    private MilestonesService milestonesService;
+
+    @Mock
+    private MilestonesRepository milestonesRepository;
+
+    @Mock
+    private UserBadgeRepository userBadgeRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testCreateMilestones() {
+        String userId = "user123";
+        Milestones milestones = new Milestones(userId, 0, 0.0, 0, 0.0, 0);
+        when(milestonesRepository.save(any(Milestones.class))).thenReturn(milestones);
+
+        Milestones result = milestonesService.createMilestones(userId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.getUserId());
+        verify(milestonesRepository, times(1)).save(any(Milestones.class));
+    }
+
+    @Test
+    void testGetMilestonesByUserId_CreateIfNotExist() {
+        String userId = "user123";
+        when(milestonesRepository.findByUserId(userId)).thenReturn(null);
+        Milestones milestones = new Milestones(userId, 0, 0.0, 0, 0.0, 0);
+        when(milestonesRepository.save(any(Milestones.class))).thenReturn(milestones);
+
+        Milestones result = milestonesService.getMilestonesByUserId(userId);
+
+        assertNotNull(result);
+        verify(milestonesRepository, times(1)).findByUserId(userId);
+        verify(milestonesRepository, times(1)).save(any(Milestones.class));
+    }
+
+    @Test
+    void testUpdateMilestones() {
+        String userId = "user123";
+        Milestones existingMilestones = new Milestones(userId, 1, 10.0, 2, 500.0, 1);
+        Milestones updatedMilestones = new Milestones(userId, 2, 20.0, 3, 1000.0, 2);
+        when(milestonesRepository.findByUserId(userId)).thenReturn(existingMilestones);
+        when(milestonesRepository.save(any(Milestones.class))).thenReturn(updatedMilestones);
+
+        Milestones result = milestonesService.updateMilestones(userId, updatedMilestones);
+
+        assertNotNull(result);
+        assertEquals(2, result.getTotalHikes());
+        verify(milestonesRepository, times(1)).save(any(Milestones.class));
+    }
+
+    @Test
+    void testIncrementTotalHikes() {
+        String userId = "user123";
+        Milestones milestones = new Milestones(userId, 1, 10.0, 2, 500.0, 1);
+        when(milestonesRepository.findByUserId(userId)).thenReturn(milestones);
+        when(milestonesRepository.save(any(Milestones.class))).thenReturn(milestones);
+
+        Milestones result = milestonesService.incrementTotalHikes(userId);
+
+        assertEquals(2, result.getTotalHikes());
+        verify(milestonesRepository, times(1)).save(any(Milestones.class));
+    }
+
+    @Test
+    void testIncrementNationalParksVisited() {
+        String userId = "user123";
+        String parkName = "Yosemite";
+        String badgeId = "badge123";
+        Milestones milestones = new Milestones(userId, 1, 10.0, 2, 500.0, 1);
+
+        try (MockedStatic<NationalParksList> mockedNationalParksList = mockStatic(NationalParksList.class)) {
+            mockedNationalParksList.when(() -> NationalParksList.isCaliforniaNationalPark(parkName)).thenReturn(true);
+            mockedNationalParksList.when(() -> NationalParksList.getBadgeIdForPark(parkName)).thenReturn(badgeId);
+            when(userBadgeRepository.findByUserIdAndBadgeId(userId, badgeId)).thenReturn(Optional.empty());
+            when(milestonesRepository.findByUserId(userId)).thenReturn(milestones);
+            when(milestonesRepository.save(any(Milestones.class))).thenReturn(milestones);
+
+            Milestones result = milestonesService.incrementNationalParksVisited(userId, parkName);
+
+            assertEquals(2, result.getNationalParksVisited());
+            verify(milestonesRepository, times(1)).save(any(Milestones.class));
+        }
+    }
+
+    @Test
+    void testDeleteMilestonesByUserId() {
+        String userId = "user123";
+        Milestones milestones = new Milestones(userId, 1, 10.0, 2, 500.0, 1);
+        when(milestonesRepository.findByUserId(userId)).thenReturn(milestones);
+
+        milestonesService.deleteMilestonesByUserId(userId);
+
+        verify(milestonesRepository, times(1)).delete(milestones);
+    }
+}

--- a/src/test/java/com/project3/project3/service/ReviewServiceTest.java
+++ b/src/test/java/com/project3/project3/service/ReviewServiceTest.java
@@ -1,0 +1,159 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.Review;
+import com.project3.project3.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllReviews() {
+        // Arrange
+        List<Review> reviews = Arrays.asList(new Review(), new Review());
+        when(reviewRepository.findAll()).thenReturn(reviews);
+
+        // Act
+        List<Review> result = reviewService.getAllReviews();
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(reviewRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetReviewsByTrailId() {
+        // Arrange
+        String trailId = "trail123";
+        List<Review> reviews = Arrays.asList(new Review(), new Review());
+        when(reviewRepository.findByTrailId(trailId)).thenReturn(reviews);
+
+        // Act
+        List<Review> result = reviewService.getReviewsByTrailId(trailId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(reviewRepository, times(1)).findByTrailId(trailId);
+    }
+
+    @Test
+    void testCalculateAverageDifficulty() {
+        // Arrange
+        String trailId = "trail123";
+        List<Review> reviews = Arrays.asList(
+                new Review("trail123", "user1", 3.5, 4.0, "Good trail", LocalDateTime.now()),
+                new Review("trail123", "user2", 4.5, 5.0, "Great trail", LocalDateTime.now())
+        );
+        when(reviewRepository.findByTrailId(trailId)).thenReturn(reviews);
+
+        // Act
+        Double result = reviewService.calculateAverageDifficulty(trailId);
+
+        // Assert
+        assertEquals(4.0, result);
+        verify(reviewRepository, times(1)).findByTrailId(trailId);
+    }
+
+    @Test
+    void testGetReviewsByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<Review> reviews = Arrays.asList(new Review(), new Review());
+        when(reviewRepository.findByUserId(userId)).thenReturn(reviews);
+
+        // Act
+        List<Review> result = reviewService.getReviewsByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(reviewRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testCreateReview() {
+        // Arrange
+        Review review = new Review("trail123", "user123", 5.0, 4.5, "Awesome trail!", LocalDateTime.now());
+        when(reviewRepository.save(any(Review.class))).thenReturn(review);
+
+        // Act
+        Review result = reviewService.createReview(review);
+
+        // Assert
+        assertNotNull(result.getTimestamp());
+        verify(reviewRepository, times(1)).save(review);
+    }
+
+    @Test
+    void testDeleteReview_Success() {
+        // Arrange
+        String reviewId = "review123";
+        when(reviewRepository.existsById(reviewId)).thenReturn(true);
+
+        // Act
+        boolean result = reviewService.deleteReview(reviewId);
+
+        // Assert
+        assertTrue(result);
+        verify(reviewRepository, times(1)).existsById(reviewId);
+        verify(reviewRepository, times(1)).deleteById(reviewId);
+    }
+
+    @Test
+    void testDeleteReview_NotFound() {
+        // Arrange
+        String reviewId = "nonexistent";
+        when(reviewRepository.existsById(reviewId)).thenReturn(false);
+
+        // Act
+        boolean result = reviewService.deleteReview(reviewId);
+
+        // Assert
+        assertFalse(result);
+        verify(reviewRepository, times(1)).existsById(reviewId);
+        verify(reviewRepository, never()).deleteById(reviewId);
+    }
+
+    @Test
+    void testUpdateReview_Success() {
+        // Arrange
+        String reviewId = "review123";
+        Review existingReview = new Review("trail123", "user123", 4.0, 3.5, "Nice trail", LocalDateTime.now());
+        Review updatedReview = new Review("trail123", "user123", 5.0, 4.5, "Updated comment", LocalDateTime.now());
+
+        when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(existingReview));
+        when(reviewRepository.save(any(Review.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        Optional<Review> result = reviewService.updateReview(reviewId, updatedReview);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(4.5, result.get().getRating());
+        assertEquals("Updated comment", result.get().getComment());
+        verify(reviewRepository, times(1)).findById(reviewId);
+        verify(reviewRepository, times(1)).save(existingReview);
+    }
+}
+

--- a/src/test/java/com/project3/project3/service/TrailImageServiceTest.java
+++ b/src/test/java/com/project3/project3/service/TrailImageServiceTest.java
@@ -1,0 +1,142 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.TrailImage;
+import com.project3.project3.repository.TrailImageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TrailImageServiceTest {
+
+    @InjectMocks
+    private TrailImageService trailImageService;
+
+    @Mock
+    private TrailImageRepository trailImageRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetImagesByTrailId() {
+        // Arrange
+        String trailId = "trail123";
+        List<TrailImage> images = Arrays.asList(new TrailImage(), new TrailImage());
+        when(trailImageRepository.findByTrailId(trailId)).thenReturn(images);
+
+        // Act
+        List<TrailImage> result = trailImageService.getImagesByTrailId(trailId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(trailImageRepository, times(1)).findByTrailId(trailId);
+    }
+
+    @Test
+    void testGetImagesByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<TrailImage> images = Arrays.asList(new TrailImage(), new TrailImage());
+        when(trailImageRepository.findByUserId(userId)).thenReturn(images);
+
+        // Act
+        List<TrailImage> result = trailImageService.getImagesByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(trailImageRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testSaveTrailImage() {
+        // Arrange
+        TrailImage trailImage = new TrailImage();
+        trailImage.setImageUrl("http://example.com/image.jpg");
+        trailImage.setTrailId("trail123");
+        trailImage.setUserId("user123");
+        trailImage.setDescription("Beautiful view");
+        when(trailImageRepository.save(any(TrailImage.class))).thenReturn(trailImage);
+
+        // Act
+        TrailImage result = trailImageService.saveTrailImage("http://example.com/image.jpg", "trail123", "user123", "Beautiful view");
+
+        // Assert
+        assertEquals("http://example.com/image.jpg", result.getImageUrl());
+        assertEquals("trail123", result.getTrailId());
+        assertEquals("user123", result.getUserId());
+        assertEquals("Beautiful view", result.getDescription());
+        verify(trailImageRepository, times(1)).save(any(TrailImage.class));
+    }
+
+    @Test
+    void testGetTrailImageById_Found() {
+        // Arrange
+        String id = "image123";
+        TrailImage trailImage = new TrailImage();
+        trailImage.setTrailId("trail123");
+        when(trailImageRepository.findById(id)).thenReturn(Optional.of(trailImage));
+
+        // Act
+        Optional<TrailImage> result = trailImageService.getTrailImageById(id);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals("trail123", result.get().getTrailId());
+        verify(trailImageRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void testGetTrailImageById_NotFound() {
+        // Arrange
+        String id = "nonexistent";
+        when(trailImageRepository.findById(id)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<TrailImage> result = trailImageService.getTrailImageById(id);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(trailImageRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void testDeleteTrailImage_Success() {
+        // Arrange
+        String id = "image123";
+        when(trailImageRepository.existsById(id)).thenReturn(true);
+
+        // Act
+        boolean result = trailImageService.deleteTrailImage(id);
+
+        // Assert
+        assertTrue(result);
+        verify(trailImageRepository, times(1)).existsById(id);
+        verify(trailImageRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    void testDeleteTrailImage_NotFound() {
+        // Arrange
+        String id = "nonexistent";
+        when(trailImageRepository.existsById(id)).thenReturn(false);
+
+        // Act
+        boolean result = trailImageService.deleteTrailImage(id);
+
+        // Assert
+        assertFalse(result);
+        verify(trailImageRepository, times(1)).existsById(id);
+        verify(trailImageRepository, never()).deleteById(id);
+    }
+}

--- a/src/test/java/com/project3/project3/service/TrailServiceTest.java
+++ b/src/test/java/com/project3/project3/service/TrailServiceTest.java
@@ -1,0 +1,168 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.Trail;
+import com.project3.project3.repository.TrailRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TrailServiceTest {
+
+    @InjectMocks
+    private TrailService trailService;
+
+    @Mock
+    private TrailRepository trailRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetAllTrails() {
+        // Arrange
+        List<Trail> trails = Arrays.asList(new Trail(), new Trail());
+        when(trailRepository.findAll()).thenReturn(trails);
+
+        // Act
+        List<Trail> result = trailService.getAllTrails();
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(trailRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetTrailById_Found() {
+        // Arrange
+        String id = "trail123";
+        Trail trail = new Trail();
+        trail.setTrailId(id);
+        when(trailRepository.findById(id)).thenReturn(Optional.of(trail));
+
+        // Act
+        Optional<Trail> result = trailService.getTrailById(id);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(id, result.get().getTrailId());
+        verify(trailRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void testGetTrailById_NotFound() {
+        // Arrange
+        String id = "nonexistent";
+        when(trailRepository.findById(id)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Trail> result = trailService.getTrailById(id);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(trailRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void testGetTrailByPlacesId_Found() {
+        // Arrange
+        String placesId = "places123";
+        Trail trail = new Trail();
+        trail.setPlacesId(placesId);
+        when(trailRepository.findByPlacesId(placesId)).thenReturn(Optional.of(trail));
+
+        // Act
+        Optional<Trail> result = trailService.getTrailByPlacesId(placesId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(placesId, result.get().getPlacesId());
+        verify(trailRepository, times(1)).findByPlacesId(placesId);
+    }
+
+    @Test
+    void testGetTrailByPlacesId_NotFound() {
+        // Arrange
+        String placesId = "nonexistent";
+        when(trailRepository.findByPlacesId(placesId)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<Trail> result = trailService.getTrailByPlacesId(placesId);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(trailRepository, times(1)).findByPlacesId(placesId);
+    }
+
+    @Test
+    void testCreateTrail() {
+        // Arrange
+        Trail trail = new Trail();
+        trail.setName("New Trail");
+        when(trailRepository.save(any(Trail.class))).thenReturn(trail);
+
+        // Act
+        Trail result = trailService.createTrail(trail);
+
+        // Assert
+        assertEquals("New Trail", result.getName());
+        verify(trailRepository, times(1)).save(trail);
+    }
+
+    @Test
+    void testUpdateTrail() {
+        // Arrange
+        String id = "trail123";
+        Trail trail = new Trail();
+        trail.setName("Updated Trail");
+        when(trailRepository.save(any(Trail.class))).thenReturn(trail);
+
+        // Act
+        Trail result = trailService.updateTrail(id, trail);
+
+        // Assert
+        assertEquals("Updated Trail", result.getName());
+        assertEquals(id, result.getTrailId());
+        verify(trailRepository, times(1)).save(trail);
+    }
+
+    @Test
+    void testDeleteTrail_Success() {
+        // Arrange
+        String id = "trail123";
+        when(trailRepository.existsById(id)).thenReturn(true);
+
+        // Act
+        boolean result = trailService.deleteTrail(id);
+
+        // Assert
+        assertTrue(result);
+        verify(trailRepository, times(1)).existsById(id);
+        verify(trailRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    void testDeleteTrail_NotFound() {
+        // Arrange
+        String id = "nonexistent";
+        when(trailRepository.existsById(id)).thenReturn(false);
+
+        // Act
+        boolean result = trailService.deleteTrail(id);
+
+        // Assert
+        assertFalse(result);
+        verify(trailRepository, times(1)).existsById(id);
+        verify(trailRepository, never()).deleteById(id);
+    }
+}

--- a/src/test/java/com/project3/project3/service/UserBadgeServiceTest.java
+++ b/src/test/java/com/project3/project3/service/UserBadgeServiceTest.java
@@ -1,0 +1,156 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.UserBadge;
+import com.project3.project3.repository.UserBadgeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserBadgeServiceTest {
+
+    @InjectMocks
+    private UserBadgeService userBadgeService;
+
+    @Mock
+    private UserBadgeRepository userBadgeRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetUserBadgesByUserId() {
+        // Arrange
+        String userId = "user123";
+        List<UserBadge> badges = Arrays.asList(new UserBadge(), new UserBadge());
+        when(userBadgeRepository.findByUserId(userId)).thenReturn(badges);
+
+        // Act
+        List<UserBadge> result = userBadgeService.getUserBadgesByUserId(userId);
+
+        // Assert
+        assertEquals(2, result.size());
+        verify(userBadgeRepository, times(1)).findByUserId(userId);
+    }
+
+    @Test
+    void testGetUserBadge_Found() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "badge123";
+        UserBadge badge = new UserBadge(userId, badgeId, LocalDateTime.now());
+        when(userBadgeRepository.findByUserIdAndBadgeId(userId, badgeId)).thenReturn(Optional.of(badge));
+
+        // Act
+        Optional<UserBadge> result = userBadgeService.getUserBadge(userId, badgeId);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(badgeId, result.get().getBadgeId());
+        verify(userBadgeRepository, times(1)).findByUserIdAndBadgeId(userId, badgeId);
+    }
+
+    @Test
+    void testGetUserBadge_NotFound() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "nonexistent";
+        when(userBadgeRepository.findByUserIdAndBadgeId(userId, badgeId)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<UserBadge> result = userBadgeService.getUserBadge(userId, badgeId);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(userBadgeRepository, times(1)).findByUserIdAndBadgeId(userId, badgeId);
+    }
+
+    @Test
+    void testAwardBadgeToUser() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "badge123";
+        UserBadge userBadge = new UserBadge(userId, badgeId, LocalDateTime.now());
+        when(userBadgeRepository.save(any(UserBadge.class))).thenReturn(userBadge);
+
+        // Act
+        UserBadge result = userBadgeService.awardBadgeToUser(userId, badgeId);
+
+        // Assert
+        assertEquals(userId, result.getUserId());
+        assertEquals(badgeId, result.getBadgeId());
+        assertNotNull(result.getAwardedTimestamp());
+        verify(userBadgeRepository, times(1)).save(any(UserBadge.class));
+    }
+
+    @Test
+    void testHasBadge_True() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "badge123";
+        when(userBadgeRepository.findByUserIdAndBadgeId(userId, badgeId)).thenReturn(Optional.of(new UserBadge()));
+
+        // Act
+        boolean result = userBadgeService.hasBadge(userId, badgeId);
+
+        // Assert
+        assertTrue(result);
+        verify(userBadgeRepository, times(1)).findByUserIdAndBadgeId(userId, badgeId);
+    }
+
+    @Test
+    void testHasBadge_False() {
+        // Arrange
+        String userId = "user123";
+        String badgeId = "nonexistent";
+        when(userBadgeRepository.findByUserIdAndBadgeId(userId, badgeId)).thenReturn(Optional.empty());
+
+        // Act
+        boolean result = userBadgeService.hasBadge(userId, badgeId);
+
+        // Assert
+        assertFalse(result);
+        verify(userBadgeRepository, times(1)).findByUserIdAndBadgeId(userId, badgeId);
+    }
+
+    @Test
+    void testRemoveBadge_Success() {
+        // Arrange
+        String id = "badge123";
+        when(userBadgeRepository.existsById(id)).thenReturn(true);
+
+        // Act
+        boolean result = userBadgeService.removeBadge(id);
+
+        // Assert
+        assertTrue(result);
+        verify(userBadgeRepository, times(1)).existsById(id);
+        verify(userBadgeRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    void testRemoveBadge_NotFound() {
+        // Arrange
+        String id = "nonexistent";
+        when(userBadgeRepository.existsById(id)).thenReturn(false);
+
+        // Act
+        boolean result = userBadgeService.removeBadge(id);
+
+        // Assert
+        assertFalse(result);
+        verify(userBadgeRepository, times(1)).existsById(id);
+        verify(userBadgeRepository, never()).deleteById(id);
+    }
+}

--- a/src/test/java/com/project3/project3/service/UserServiceTest.java
+++ b/src/test/java/com/project3/project3/service/UserServiceTest.java
@@ -1,0 +1,185 @@
+package com.project3.project3.service;
+
+import com.project3.project3.model.User;
+import com.project3.project3.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testLoadUserByUsername_Found() {
+        // Arrange
+        String username = "testuser";
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("hashedpassword");
+        user.setRoles(List.of("ROLE_USER"));
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        // Act
+        UserDetails result = userService.loadUserByUsername(username);
+
+        // Assert
+        assertEquals(username, result.getUsername());
+        assertEquals("hashedpassword", result.getPassword());
+        assertTrue(result.getAuthorities().stream()
+                .anyMatch(auth -> auth.getAuthority().equals("ROLE_USER")));
+        verify(userRepository, times(1)).findByUsername(username);
+    }
+
+    @Test
+    void testLoadUserByUsername_NotFound() {
+        // Arrange
+        String username = "nonexistent";
+        when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(UsernameNotFoundException.class, () -> userService.loadUserByUsername(username));
+        verify(userRepository, times(1)).findByUsername(username);
+    }
+
+    @Test
+    void testFindUserByUsername_Found() {
+        // Arrange
+        String username = "testuser";
+        User user = new User();
+        user.setUsername(username);
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(user));
+
+        // Act
+        Optional<User> result = userService.findUserByUsername(username);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertEquals(username, result.get().getUsername());
+        verify(userRepository, times(1)).findByUsername(username);
+    }
+
+    @Test
+    void testFindUserByUsername_NotFound() {
+        // Arrange
+        String username = "nonexistent";
+        when(userRepository.findByUsername(username)).thenReturn(Optional.empty());
+
+        // Act
+        Optional<User> result = userService.findUserByUsername(username);
+
+        // Assert
+        assertFalse(result.isPresent());
+        verify(userRepository, times(1)).findByUsername(username);
+    }
+
+    @Test
+    void testSaveUser() {
+        // Arrange
+        User user = new User();
+        user.setPassword("plaintextpassword");
+        when(passwordEncoder.encode("plaintextpassword")).thenReturn("hashedpassword");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        User result = userService.saveUser(user);
+
+        // Assert
+        assertEquals("hashedpassword", result.getPassword());
+        assertEquals(List.of("ROLE_USER"), result.getRoles());
+        verify(passwordEncoder, times(1)).encode("plaintextpassword");
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    void testDeleteUserById_Success() {
+        // Arrange
+        String userId = "user123";
+        when(userRepository.existsById(userId)).thenReturn(true);
+
+        // Act
+        boolean result = userService.deleteUserById(userId);
+
+        // Assert
+        assertTrue(result);
+        verify(userRepository, times(1)).existsById(userId);
+        verify(userRepository, times(1)).deleteById(userId);
+    }
+
+    @Test
+    void testDeleteUserById_NotFound() {
+        // Arrange
+        String userId = "nonexistent";
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        // Act
+        boolean result = userService.deleteUserById(userId);
+
+        // Assert
+        assertFalse(result);
+        verify(userRepository, times(1)).existsById(userId);
+        verify(userRepository, never()).deleteById(userId);
+    }
+
+    @Test
+    void testAssignRole() {
+        // Arrange
+        String userId = "user123";
+        String role = "ROLE_ADMIN";
+        User user = new User();
+        user.setRoles(new ArrayList<>());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        Optional<User> result = userService.assignRole(userId, role);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertTrue(result.get().getRoles().contains(role));
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    void testRemoveRole() {
+        // Arrange
+        String userId = "user123";
+        String role = "ROLE_USER";
+        User user = new User();
+        user.setRoles(new ArrayList<>(List.of(role)));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        Optional<User> result = userService.removeRole(userId, role);
+
+        // Assert
+        assertTrue(result.isPresent());
+        assertFalse(result.get().getRoles().contains(role));
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+    }
+}


### PR DESCRIPTION
### Overview
This PR adds comprehensive unit tests for the `JwtRequestFilter` to validate its behavior and ensure robust JWT-based authentication functionality in the application.

### Changes Made
- Added the test class `JwtRequestFilterTest` in the `test/java/com/project3/project3/security/` directory.
- Implemented the following test cases:
  1. **shouldBypassFilterForAuthEndpoint**: Verifies that the filter bypasses `/api/auth/**` endpoints without attempting token validation.
  2. **shouldAuthenticateUserWithValidToken**: Confirms that a valid JWT token sets authentication in the `SecurityContext` and allows the request to proceed.
  3. **shouldNotAuthenticateUserWithInvalidToken**: Ensures that invalid or expired JWT tokens do not set authentication in the `SecurityContext`.

### Testing
- Used `Mockito` to mock dependencies (`JwtService`, `UserService`, etc.).
- Verified proper clearing of the `SecurityContext` before each test to avoid test contamination.
- Added assertions to check the behavior of the `SecurityContext` and mock filter interactions.

### Additional Notes
- Mocked `HttpServletRequest.getRequestURI()` to simulate real HTTP requests.
- Mocked `HttpServletRequest.getHeader()` for token handling.
- All tests pass successfully, confirming the correctness of the `JwtRequestFilter`.


